### PR TITLE
Add combined strategy notebook

### DIFF
--- a/Combined_Strategies.ipynb
+++ b/Combined_Strategies.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0f9c0608",
+   "metadata": {},
+   "source": [
+    "# Consolidated Betting Strategy\n",
+    "This notebook combines previous analysis techniques for double chance and over/under accumulator bets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b655420c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import itertools\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.ensemble import GradientBoostingRegressor\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d925b56a",
+   "metadata": {},
+   "source": [
+    "## Example Match Data\n",
+    "Replace or extend this list with your own probabilities, odds, and expected goals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e69f7d4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matches = [\n",
+    "    {'match': 'Club Brugge vs Aston Villa', 'home_team':'Club Brugge', 'away_team':'Aston Villa', 'home_win_prob':0.286, 'draw_prob':0.294, 'away_win_prob':0.5, 'home_win_odds':3.5, 'draw_odds':3.4, 'away_win_odds':2.0, 'home_xg':1.2, 'away_xg':1.8},\n",
+    "    {'match': 'Shakhtar Donetsk vs Young Boys', 'home_team':'Shakhtar Donetsk', 'away_team':'Young Boys', 'home_win_prob':0.476, 'draw_prob':0.303, 'away_win_prob':0.278, 'home_win_odds':2.1, 'draw_odds':3.3, 'away_win_odds':3.6, 'home_xg':1.5, 'away_xg':1.1},\n",
+    "    {'match': 'Bayern Munich vs Benfica', 'home_team':'Bayern Munich', 'away_team':'Benfica', 'home_win_prob':0.714, 'draw_prob':0.211, 'away_win_prob':0.133, 'home_win_odds':1.4, 'draw_odds':4.75, 'away_win_odds':7.5, 'home_xg':2.3, 'away_xg':0.8},\n",
+    "    {'match': 'Crvena Zvezda vs Barcelona', 'home_team':'Crvena Zvezda', 'away_team':'Barcelona', 'home_win_prob':0.167, 'draw_prob':0.25, 'away_win_prob':0.667, 'home_win_odds':6.0, 'draw_odds':4.0, 'away_win_odds':1.5, 'home_xg':0.9, 'away_xg':2.1},\n",
+    "    {'match': 'Feyenoord vs FC Salzburg', 'home_team':'Feyenoord', 'away_team':'FC Salzburg', 'home_win_prob':0.444, 'draw_prob':0.286, 'away_win_prob':0.323, 'home_win_odds':2.25, 'draw_odds':3.5, 'away_win_odds':3.1, 'home_xg':1.6, 'away_xg':1.3},\n",
+    "    {'match': 'Inter Milan vs Arsenal', 'home_team':'Inter Milan', 'away_team':'Arsenal', 'home_win_prob':0.4, 'draw_prob':0.303, 'away_win_prob':0.357, 'home_win_odds':2.5, 'draw_odds':3.3, 'away_win_odds':2.8, 'home_xg':1.4, 'away_xg':1.2},\n",
+    "    {'match': 'PSG vs Atletico Madrid', 'home_team':'PSG', 'away_team':'Atletico Madrid', 'home_win_prob':0.556, 'draw_prob':0.278, 'away_win_prob':0.222, 'home_win_odds':1.8, 'draw_odds':3.6, 'away_win_odds':4.5, 'home_xg':1.7, 'away_xg':0.9},\n",
+    "    {'match': 'Sparta Prague vs Brest', 'home_team':'Sparta Prague', 'away_team':'Brest', 'home_win_prob':0.625, 'draw_prob':0.25, 'away_win_prob':0.182, 'home_win_odds':1.6, 'draw_odds':4.0, 'away_win_odds':5.5, 'home_xg':1.8, 'away_xg':0.7}\n",
+    "]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cce95381",
+   "metadata": {},
+   "source": [
+    "## Helper Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17a86c1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calculate_double_chance_labels(home_team, away_team, home_win_prob, draw_prob, away_win_prob):\n",
+    "    home_draw_label = f\"{home_team} or Draw\"\n",
+    "    away_draw_label = f\"{away_team} or Draw\"\n",
+    "    home_away_label = f\"{home_team} or {away_team}\"\n",
+    "    return (\n",
+    "        (home_draw_label, home_win_prob + draw_prob),\n",
+    "        (away_draw_label, away_win_prob + draw_prob),\n",
+    "        (home_away_label, home_win_prob + away_win_prob)\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3d5cae6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for match in matches:\n",
+    "    (home_draw_label, home_draw), (away_draw_label, away_draw), (home_away_label, home_away) = calculate_double_chance_labels(\n",
+    "        match['home_team'], match['away_team'], match['home_win_prob'], match['draw_prob'], match['away_win_prob']\n",
+    "    )\n",
+    "    match['home_draw'] = (home_draw_label, home_draw)\n",
+    "    match['away_draw'] = (away_draw_label, away_draw)\n",
+    "    match['home_away'] = (home_away_label, home_away)\n",
+    "    match['estimated_goals'] = round(match['home_xg'] + match['away_xg'], 2)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a24a9010",
+   "metadata": {},
+   "source": [
+    "### Generate Accumulator Combinations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1a4a46d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_accumulator_df(match_list, outcome_types=('home_draw','away_draw','home_away')):\n",
+    "    combinations = list(itertools.product(outcome_types, repeat=len(match_list)))\n",
+    "    results = []\n",
+    "    for combo in combinations:\n",
+    "        cum_prob = 1.0\n",
+    "        cum_odds = 1.0\n",
+    "        selections = []\n",
+    "        for i, outcome in enumerate(combo):\n",
+    "            label, prob = match_list[i][outcome]\n",
+    "            cum_prob *= prob\n",
+    "            if outcome == 'home_draw':\n",
+    "                cum_odds *= match_list[i]['home_win_odds']\n",
+    "            elif outcome == 'away_draw':\n",
+    "                cum_odds *= match_list[i]['away_win_odds']\n",
+    "            else:\n",
+    "                cum_odds *= match_list[i]['draw_odds']\n",
+    "            selections.append(label)\n",
+    "        exp_value = cum_prob * (cum_odds - 1)\n",
+    "        results.append((*selections, cum_prob, cum_odds, exp_value))\n",
+    "    columns = [f'Match {i+1} Selection' for i in range(len(match_list))]\n",
+    "    columns += ['Cumulative Probability','Cumulative Odds','Expected Value']\n",
+    "    return pd.DataFrame(results, columns=columns)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa7198d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acca_df = generate_accumulator_df(matches)\n",
+    "acca_df.sort_values('Expected Value', ascending=False, inplace=True)\n",
+    "acca_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b8b076f",
+   "metadata": {},
+   "source": [
+    "### Highlight Best Bets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91b2c43b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def highlight_best_bets(df, top=50):\n",
+    "    ev_thresh = df['Expected Value'].quantile(0.85)\n",
+    "    prob_min = df['Cumulative Probability'].quantile(0.45)\n",
+    "    prob_max = df['Cumulative Probability'].quantile(0.90)\n",
+    "    odds_min = df['Cumulative Odds'].quantile(0.25)\n",
+    "    filtered = df[(df['Expected Value']>=ev_thresh) &\n",
+    "                  (df['Cumulative Probability']>=prob_min) &\n",
+    "                  (df['Cumulative Probability']<=prob_max) &\n",
+    "                  (df['Cumulative Odds']>=odds_min)]\n",
+    "    return filtered.sort_values('Expected Value', ascending=False).head(top)\n",
+    "\n",
+    "best_bets = highlight_best_bets(acca_df)\n",
+    "best_bets.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84fd3751",
+   "metadata": {},
+   "source": [
+    "### Expected Value vs Probability Visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "430d7002",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = acca_df['Cumulative Probability'].values\n",
+    "y = acca_df['Expected Value'].values\n",
+    "model = GradientBoostingRegressor(n_estimators=100, learning_rate=0.1, max_depth=3, random_state=42)\n",
+    "model.fit(x.reshape(-1,1), y)\n",
+    "cv = cross_val_score(model, x.reshape(-1,1), y, cv=5, scoring='neg_mean_squared_error')\n",
+    "print(f'Cross-validated MSE: {-cv.mean():.4f}')\n",
+    "\n",
+    "x_new = np.linspace(x.min(), x.max(), 200)\n",
+    "y_gb = model.predict(x_new.reshape(-1,1))\n",
+    "\n",
+    "plt.figure(figsize=(8,6))\n",
+    "plt.scatter(x, y, c=acca_df['Cumulative Odds'], cmap='viridis', s=20, alpha=0.6)\n",
+    "plt.plot(x_new, y_gb, color='magenta', label='Gradient Boosting')\n",
+    "plt.colorbar(label='Cumulative Odds')\n",
+    "plt.xlabel('Cumulative Probability')\n",
+    "plt.ylabel('Expected Value')\n",
+    "plt.title('Expected Value vs Probability')\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d19bfe3",
+   "metadata": {},
+   "source": [
+    "### Selecting Example 6-Team Accumulator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70bad9c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "six_team = matches[:6]\n",
+    "acca_6 = generate_accumulator_df(six_team)\n",
+    "acca_6.sort_values('Expected Value', ascending=False, inplace=True)\n",
+    "acca_6.head(20)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b87adf1",
+   "metadata": {},
+   "source": [
+    "### Selecting Example 8-Team Accumulator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "822648c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acca_8 = generate_accumulator_df(matches)\n",
+    "acca_8.sort_values('Expected Value', ascending=False, inplace=True)\n",
+    "acca_8.head(20)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c322ca07",
+   "metadata": {},
+   "source": [
+    "This notebook can be extended with your own match data and tuned filtering parameters to suit different risk strategies."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- consolidate existing analysis approaches into a single notebook
- provide helper functions for double chance accumulator generation and filtering
- include example 6 and 8 team accumulator generation with EV vs probability visualization

## Testing
- `pip install nbformat --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68407354965c832bbea09e0ba1435a1a