### PR TITLE
Add configurable thresholds for bet selection

### DIFF
--- a/Combined_Strategies.ipynb
+++ b/Combined_Strategies.ipynb
@@ -161,18 +161,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def highlight_best_bets(df, top=50):\n",
-    "    ev_thresh = df['Expected Value'].quantile(0.85)\n",
-    "    prob_min = df['Cumulative Probability'].quantile(0.45)\n",
-    "    prob_max = df['Cumulative Probability'].quantile(0.90)\n",
-    "    odds_min = df['Cumulative Odds'].quantile(0.25)\n",
+    "def highlight_best_bets(df, top=50, min_ev=None, min_prob=None, max_prob=None, min_odds=None):\n",
+    "    ev_thresh = df['Expected Value'].quantile(0.85) if min_ev is None else min_ev\n",
+    "    prob_min = df['Cumulative Probability'].quantile(0.45) if min_prob is None else min_prob\n",
+    "    prob_max = df['Cumulative Probability'].quantile(0.90) if max_prob is None else max_prob\n",
+    "    odds_min = df['Cumulative Odds'].quantile(0.25) if min_odds is None else min_odds\n",
     "    filtered = df[(df['Expected Value']>=ev_thresh) &\n",
     "                  (df['Cumulative Probability']>=prob_min) &\n",
     "                  (df['Cumulative Probability']<=prob_max) &\n",
     "                  (df['Cumulative Odds']>=odds_min)]\n",
-    "    return filtered.sort_values('Expected Value', ascending=False).head(top)\n",
+    "    return filtered.sort_values('Expected Value', ascending=False).head(top)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuration for highlight_best_bets\n",
+    "MIN_EV = 0.1\n",
+    "MIN_PROB = 0.5\n",
+    "MAX_PROB = 0.7\n",
+    "MIN_ODDS = 1.5\n",
     "\n",
-    "best_bets = highlight_best_bets(acca_df)\n",
+    "best_bets = highlight_best_bets(acca_df, top=50, min_ev=MIN_EV, min_prob=MIN_PROB, max_prob=MAX_PROB, min_odds=MIN_ODDS)\n",
     "best_bets.head()\n"
    ]
   },

--- a/examples/highlight_best_bets_example.py
+++ b/examples/highlight_best_bets_example.py
@@ -1,0 +1,54 @@
+"""Example scenarios for ``highlight_best_bets``.
+
+This script creates a toy accumulator data set and shows how different
+risk parameters affect the resulting selections.
+"""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Allow running the example directly without installing the package
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+
+from highlight_best_bets import highlight_best_bets
+
+def build_demo_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Expected Value": [0.05, 0.12, -0.02, 0.08, 0.15],
+            "Cumulative Probability": [0.55, 0.40, 0.65, 0.30, 0.50],
+            "Cumulative Odds": [2.1, 1.8, 2.5, 3.0, 1.6],
+        }
+    )
+
+def main() -> None:
+    df = build_demo_df()
+
+    # Conservative strategy: only consider high probability and high EV bets
+    conservative = highlight_best_bets(
+        df,
+        min_ev=0.1,
+        min_prob=0.5,
+        max_prob=0.7,
+        min_odds=1.5,
+        top=3,
+    )
+
+    # Aggressive strategy: accept lower probabilities and EVs
+    aggressive = highlight_best_bets(
+        df,
+        min_ev=-0.05,
+        min_prob=0.3,
+        max_prob=0.8,
+        min_odds=1.2,
+        top=3,
+    )
+
+    print("Conservative strategy selections:\n", conservative, sep="")
+    print("\nAggressive strategy selections:\n", aggressive, sep="")
+
+if __name__ == "__main__":
+    main()

--- a/highlight_best_bets.py
+++ b/highlight_best_bets.py
@@ -1,0 +1,99 @@
+"""Bet filtering utilities.
+
+This module exposes :func:`highlight_best_bets` which filters accumulator
+combinations based on expected value, cumulative probability and cumulative
+odds.  Users can supply absolute threshold values to tailor the selection to
+their risk profile.  When a threshold is not provided, sensible percentile
+defaults are used to emulate the previous behaviour of the project.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+from typing import Optional
+
+
+def highlight_best_bets(
+    df: pd.DataFrame,
+    top: int = 50,
+    *,
+    min_ev: Optional[float] = None,
+    min_prob: Optional[float] = None,
+    max_prob: Optional[float] = None,
+    min_odds: Optional[float] = None,
+    ev_quantile: float = 0.85,
+    prob_min_quantile: float = 0.45,
+    prob_max_quantile: float = 0.90,
+    odds_min_quantile: float = 0.25,
+) -> pd.DataFrame:
+    """Return the strongest accumulator combinations.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with at least ``Expected Value``, ``Cumulative Probability``
+        and ``Cumulative Odds`` columns.
+    top:
+        Maximum number of rows to return after filtering.
+    min_ev, min_prob, max_prob, min_odds:
+        Absolute thresholds used to filter the DataFrame.  When ``None`` the
+        respective ``*_quantile`` value is used instead to maintain the old
+        percentile based defaults.
+    ev_quantile, prob_min_quantile, prob_max_quantile, odds_min_quantile:
+        Quantile defaults used when an absolute threshold is not supplied.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Filtered and sorted by expected value in descending order.
+    """
+
+    ev_thresh = (
+        df["Expected Value"].quantile(ev_quantile)
+        if min_ev is None
+        else min_ev
+    )
+    prob_min_val = (
+        df["Cumulative Probability"].quantile(prob_min_quantile)
+        if min_prob is None
+        else min_prob
+    )
+    prob_max_val = (
+        df["Cumulative Probability"].quantile(prob_max_quantile)
+        if max_prob is None
+        else max_prob
+    )
+    odds_min_val = (
+        df["Cumulative Odds"].quantile(odds_min_quantile)
+        if min_odds is None
+        else min_odds
+    )
+
+    filtered = df[
+        (df["Expected Value"] >= ev_thresh)
+        & (df["Cumulative Probability"] >= prob_min_val)
+        & (df["Cumulative Probability"] <= prob_max_val)
+        & (df["Cumulative Odds"] >= odds_min_val)
+    ]
+
+    return filtered.sort_values("Expected Value", ascending=False).head(top)
+
+
+if __name__ == "__main__":
+    # Simple demonstration when module executed directly.
+    data = {
+        "Expected Value": [0.05, 0.12, -0.02, 0.08, 0.15],
+        "Cumulative Probability": [0.55, 0.40, 0.65, 0.30, 0.50],
+        "Cumulative Odds": [2.1, 1.8, 2.5, 3.0, 1.6],
+    }
+    demo_df = pd.DataFrame(data)
+
+    conservative = highlight_best_bets(
+        demo_df, min_ev=0.1, min_prob=0.5, max_prob=0.7, min_odds=1.5, top=3
+    )
+    aggressive = highlight_best_bets(
+        demo_df, min_ev=-0.05, min_prob=0.3, max_prob=0.8, min_odds=1.2, top=3
+    )
+
+    print("Conservative strategy:\n", conservative)
+    print("\nAggressive strategy:\n", aggressive)


### PR DESCRIPTION
## Summary
- Allow `highlight_best_bets` to accept absolute EV, probability, and odds thresholds in addition to percentile defaults
- Add configuration cell in `Combined_Strategies.ipynb` to expose these parameters
- Provide example script showing conservative vs aggressive accumulator strategies

## Testing
- `python -m py_compile highlight_best_bets.py examples/highlight_best_bets_example.py`
- `python examples/highlight_best_bets_example.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac39f73808832b8a7b3c0cd375300c