### PR TITLE
Add National League over-2.5 backtest

### DIFF
--- a/analysis/national_league/backtest.ipynb
+++ b/analysis/national_league/backtest.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "160ff404",
+   "metadata": {},
+   "source": [
+    "# National League Backtest\n",
+    "This notebook simulates wagering strategies on National League matches using model-derived probabilities and available market odds. It tracks bankroll performance, return on investment (ROI), and maximum drawdown and compares the model-based approach against a simple baseline strategy of betting Over 2.5 goals when the odds are below 1.70."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "36752da6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-25T11:03:33.429609Z",
+     "iopub.status.busy": "2025-08-25T11:03:33.429217Z",
+     "iopub.status.idle": "2025-08-25T11:03:34.094447Z",
+     "shell.execute_reply": "2025-08-25T11:03:34.093338Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "from pathlib import Path\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "# Ensure we run from the repository root\n",
+    "repo_root = Path().resolve().parents[1]\n",
+    "os.chdir(repo_root)\n",
+    "\n",
+    "files = sorted(Path('.').glob('england-national-league-matches-*-stats.csv'))\n",
+    "\n",
+    "df = pd.concat(pd.read_csv(f) for f in files)\n",
+    "# Keep relevant columns and drop rows with missing data\n",
+    "cols = ['timestamp','total_goal_count','odds_ft_over25','over_25_percentage_pre_match']\n",
+    "df = df[cols].dropna()\n",
+    "# Convert percentage to probability\n",
+    "df['model_prob'] = df['over_25_percentage_pre_match'] / 100.0\n",
+    "df.sort_values('timestamp', inplace=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0cbc38f4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-25T11:03:34.098633Z",
+     "iopub.status.busy": "2025-08-25T11:03:34.098304Z",
+     "iopub.status.idle": "2025-08-25T11:03:34.258692Z",
+     "shell.execute_reply": "2025-08-25T11:03:34.257463Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model-based strategy: {'final_bankroll': np.float64(91.64999999999999), 'profit': np.float64(-8.350000000000009), 'roi': np.float64(-0.023521126760563404), 'max_drawdown': np.float64(26.040000000000063), 'total_staked': 355.0}\n",
+      "Baseline strategy: {'final_bankroll': np.float64(-418.1199999999999), 'profit': np.float64(-518.1199999999999), 'roi': np.float64(-0.5668708971553609), 'max_drawdown': np.float64(529.62), 'total_staked': 914.0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "def simulate(strategy, stake=1.0, starting_bankroll=100.0):\n",
+    "    bankroll = starting_bankroll\n",
+    "    bankroll_history = [bankroll]\n",
+    "    total_staked = 0.0\n",
+    "    for _, row in df.iterrows():\n",
+    "        odds = row['odds_ft_over25']\n",
+    "        p = row['model_prob']\n",
+    "        result = row['total_goal_count'] > 2\n",
+    "        if strategy(p, odds):\n",
+    "            bankroll -= stake\n",
+    "            total_staked += stake\n",
+    "            if result:\n",
+    "                bankroll += stake * odds\n",
+    "        bankroll_history.append(bankroll)\n",
+    "    profit = bankroll - starting_bankroll\n",
+    "    roi = profit / total_staked if total_staked else 0.0\n",
+    "    bankroll_series = pd.Series(bankroll_history)\n",
+    "    running_max = bankroll_series.cummax()\n",
+    "    drawdown = running_max - bankroll_series\n",
+    "    max_drawdown = drawdown.max()\n",
+    "    metrics = {\n",
+    "        'final_bankroll': bankroll,\n",
+    "        'profit': profit,\n",
+    "        'roi': roi,\n",
+    "        'max_drawdown': max_drawdown,\n",
+    "        'total_staked': total_staked,\n",
+    "    }\n",
+    "    return bankroll_history, metrics\n",
+    "\n",
+    "def model_strategy(p, odds):\n",
+    "    return p * odds > 1  # positive expected value\n",
+    "\n",
+    "\n",
+    "def baseline_strategy(p, odds):\n",
+    "    return odds < 1.70\n",
+    "\n",
+    "model_history, model_results = simulate(model_strategy)\n",
+    "baseline_history, baseline_results = simulate(baseline_strategy)\n",
+    "\n",
+    "print('Model-based strategy:', model_results)\n",
+    "print('Baseline strategy:', baseline_results)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add National League backtesting notebook that simulates wagers using model probabilities and market odds
- Track bankroll, ROI, and max drawdown while comparing to an always-over-2.5 baseline

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac4248aea8832ba3b98d0f34822962