### PR TITLE
feat: add accumulator simulation notebook

### DIFF
--- a/analysis/national_league/accumulator_sim.ipynb
+++ b/analysis/national_league/accumulator_sim.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "87f1d876",
+   "metadata": {},
+   "source": [
+    "# National League Accumulator Simulation\n",
+    "\n",
+    "This notebook demonstrates how to combine multiple matches into a betting accumulator and evaluate the expected return on investment (ROI)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d1f088d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from math import factorial\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a240ff2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load match data for several seasons\n",
+    "files = {\n",
+    "    '2023-24': 'england-national-league-matches-2023-to-2024-stats.csv',\n",
+    "    '2024-25': 'england-national-league-matches-2024-to-2025-stats.csv',\n",
+    "    '2025-26': 'england-national-league-matches-2025-to-2026-stats.csv'\n",
+    "}\n",
+    "seasons = {season: pd.read_csv(path) for season, path in files.items()}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07a7369c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from math import exp\n",
+    "\n",
+    "def implied_probs(home_odds, draw_odds, away_odds):\n",
+    "    probs = np.array([1/home_odds, 1/draw_odds, 1/away_odds], dtype=float)\n",
+    "    return probs / probs.sum()\n",
+    "\n",
+    "def p_double_chance(row, selection='1X'):\n",
+    "    home, draw, away = implied_probs(row['odds_ft_home_team_win'], row['odds_ft_draw'], row['odds_ft_away_team_win'])\n",
+    "    if selection == '1X':\n",
+    "        return home + draw\n",
+    "    if selection == '12':\n",
+    "        return home + away\n",
+    "    if selection == 'X2':\n",
+    "        return draw + away\n",
+    "    raise ValueError('selection must be 1X, 12, or X2')\n",
+    "\n",
+    "def poisson_pmf(lmbda, k):\n",
+    "    return (lmbda**k * exp(-lmbda)) / factorial(k)\n",
+    "\n",
+    "def p_goal_range(row, low=2, high=3):\n",
+    "    lmbda = row['Home Team Pre-Match xG'] + row['Away Team Pre-Match xG']\n",
+    "    return sum(poisson_pmf(lmbda, g) for g in range(low, high+1))\n",
+    "\n",
+    "def accumulator_probability(probs):\n",
+    "    return float(np.prod(probs))\n",
+    "\n",
+    "def accumulator_odds(odds):\n",
+    "    return float(np.prod(odds))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79245e20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example accumulator using double chance selections\n",
+    "season_df = seasons['2024-25']\n",
+    "slate = season_df.head(3)\n",
+    "legs = []\n",
+    "for _, row in slate.iterrows():\n",
+    "    prob = p_double_chance(row, '1X')\n",
+    "    odds = 1 / prob\n",
+    "    result = (row['home_team_goal_count'] >= row['away_team_goal_count'])\n",
+    "    legs.append({'match': f\"{row['home_team_name']} vs {row['away_team_name']}\", 'prob': prob, 'odds': odds, 'result': result})\n",
+    "acc_prob = accumulator_probability([leg['prob'] for leg in legs])\n",
+    "acc_odds = accumulator_odds([leg['odds'] for leg in legs])\n",
+    "expected_roi = acc_prob * acc_odds - 1\n",
+    "print('Accumulator probability:', acc_prob)\n",
+    "print('Combined odds:', acc_odds)\n",
+    "print('Expected ROI:', expected_roi)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c72583ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simulate bankroll trajectories across seasons\n",
+    "\n",
+    "def simulate_season(df, stake=1.0, leg_count=3):\n",
+    "    bankroll = [100]\n",
+    "    for date, day in df.groupby('date_GMT'):\n",
+    "        slate = day.head(leg_count)\n",
+    "        if len(slate) < leg_count:\n",
+    "            continue\n",
+    "        probs, odds, results = [], [], []\n",
+    "        for _, row in slate.iterrows():\n",
+    "            prob = p_double_chance(row, '1X')\n",
+    "            probs.append(prob)\n",
+    "            odds.append(1/prob)\n",
+    "            results.append(row['home_team_goal_count'] >= row['away_team_goal_count'])\n",
+    "        acc_prob = accumulator_probability(probs)\n",
+    "        acc_odds = accumulator_odds(odds)\n",
+    "        win = all(results)\n",
+    "        bankroll.append(bankroll[-1] - stake + (stake*acc_odds if win else 0))\n",
+    "    return bankroll\n",
+    "\n",
+    "trajectories = {season: simulate_season(df) for season, df in seasons.items()}\n",
+    "for season, bal in trajectories.items():\n",
+    "    plt.plot(bal, label=season)\n",
+    "plt.title('Bankroll Trajectories')\n",
+    "plt.xlabel('Bet Number')\n",
+    "plt.ylabel('Bankroll')\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add national league accumulator simulation notebook
- include probability helpers and bankroll trajectory plot

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac42e09b14832b95c1bdc0caff8fb5