### PR TITLE
Consolidate all strategies into single notebook

### DIFF
--- a/Consolidated_Strategies.ipynb
+++ b/Consolidated_Strategies.ipynb
@@ -1,0 +1,250 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e06977fc",
+   "metadata": {},
+   "source": [
+    "# Consolidated Strategies Notebook\n",
+    "Combines double-chance and win/draw/away strategies with improved filtering and visualization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95aa8019",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import itertools\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.ensemble import GradientBoostingRegressor\n",
+    "from sklearn.model_selection import cross_val_score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f6854f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matches = [\n",
+    "    {'match': 'Club Brugge vs Aston Villa', 'home_team':'Club Brugge', 'away_team':'Aston Villa', 'home_win_prob':0.286, 'draw_prob':0.294, 'away_win_prob':0.5, 'home_win_odds':3.5, 'draw_odds':3.4, 'away_win_odds':2.0, 'home_draw_odds':1.72, 'away_draw_odds':1.26, 'home_away_odds':1.27, 'home_xg':1.2, 'away_xg':1.8},\n",
+    "    {'match': 'Shakhtar Donetsk vs Young Boys', 'home_team':'Shakhtar Donetsk', 'away_team':'Young Boys', 'home_win_prob':0.476, 'draw_prob':0.303, 'away_win_prob':0.278, 'home_win_odds':2.1, 'draw_odds':3.3, 'away_win_odds':3.6, 'home_draw_odds':1.28, 'away_draw_odds':1.72, 'home_away_odds':1.33, 'home_xg':1.5, 'away_xg':1.1},\n",
+    "    {'match': 'Bayern Munich vs Benfica', 'home_team':'Bayern Munich', 'away_team':'Benfica', 'home_win_prob':0.714, 'draw_prob':0.211, 'away_win_prob':0.133, 'home_win_odds':1.4, 'draw_odds':4.75, 'away_win_odds':7.5, 'home_draw_odds':1.08, 'away_draw_odds':2.91, 'home_away_odds':1.18, 'home_xg':2.3, 'away_xg':0.8},\n",
+    "    {'match': 'Crvena Zvezda vs Barcelona', 'home_team':'Crvena Zvezda', 'away_team':'Barcelona', 'home_win_prob':0.167, 'draw_prob':0.25, 'away_win_prob':0.667, 'home_win_odds':6.0, 'draw_odds':4.0, 'away_win_odds':1.5, 'home_draw_odds':2.4, 'away_draw_odds':1.09, 'home_away_odds':1.2, 'home_xg':0.9, 'away_xg':2.1},\n",
+    "    {'match': 'Feyenoord vs FC Salzburg', 'home_team':'Feyenoord', 'away_team':'FC Salzburg', 'home_win_prob':0.444, 'draw_prob':0.286, 'away_win_prob':0.323, 'home_win_odds':2.25, 'draw_odds':3.5, 'away_win_odds':3.1, 'home_draw_odds':1.37, 'away_draw_odds':1.64, 'home_away_odds':1.3, 'home_xg':1.6, 'away_xg':1.3},\n",
+    "    {'match': 'Inter Milan vs Arsenal', 'home_team':'Inter Milan', 'away_team':'Arsenal', 'home_win_prob':0.4, 'draw_prob':0.303, 'away_win_prob':0.357, 'home_win_odds':2.5, 'draw_odds':3.3, 'away_win_odds':2.8, 'home_draw_odds':1.42, 'away_draw_odds':1.51, 'home_away_odds':1.32, 'home_xg':1.4, 'away_xg':1.2},\n",
+    "    {'match': 'PSG vs Atletico Madrid', 'home_team':'PSG', 'away_team':'Atletico Madrid', 'home_win_prob':0.556, 'draw_prob':0.278, 'away_win_prob':0.222, 'home_win_odds':1.8, 'draw_odds':3.6, 'away_win_odds':4.5, 'home_draw_odds':1.2, 'away_draw_odds':2.0, 'home_away_odds':1.29, 'home_xg':1.7, 'away_xg':0.9},\n",
+    "    {'match': 'Sparta Prague vs Brest', 'home_team':'Sparta Prague', 'away_team':'Brest', 'home_win_prob':0.625, 'draw_prob':0.25, 'away_win_prob':0.182, 'home_win_odds':1.6, 'draw_odds':4.0, 'away_win_odds':5.5, 'home_draw_odds':1.14, 'away_draw_odds':2.32, 'home_away_odds':1.24, 'home_xg':1.8, 'away_xg':0.7}\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91501458",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calculate_double_chance_labels(home_team, away_team, home_win_prob, draw_prob, away_win_prob):\n",
+    "    home_draw_label = f'{home_team} or Draw'\n",
+    "    away_draw_label = f'{away_team} or Draw'\n",
+    "    home_away_label = f'{home_team} or {away_team}'\n",
+    "    return (\n",
+    "        (home_draw_label, home_win_prob + draw_prob),\n",
+    "        (away_draw_label, away_win_prob + draw_prob),\n",
+    "        (home_away_label, home_win_prob + away_win_prob)\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2059efc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for match in matches:\n",
+    "    (home_draw_label, home_draw), (away_draw_label, away_draw), (home_away_label, home_away) = calculate_double_chance_labels(\n",
+    "        match['home_team'], match['away_team'], match['home_win_prob'], match['draw_prob'], match['away_win_prob']\n",
+    "    )\n",
+    "    match['home_draw'] = (home_draw_label, home_draw)\n",
+    "    match['away_draw'] = (away_draw_label, away_draw)\n",
+    "    match['home_away'] = (home_away_label, home_away)\n",
+    "    match['estimated_goals'] = round(match['home_xg'] + match['away_xg'], 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14a37b16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_double_chance_df(match_list, outcome_types=('home_draw','away_draw','home_away')):\n",
+    "    combinations = list(itertools.product(outcome_types, repeat=len(match_list)))\n",
+    "    results = []\n",
+    "    for combo in combinations:\n",
+    "        cum_prob = 1.0\n",
+    "        cum_odds = 1.0\n",
+    "        selections = []\n",
+    "        for i, outcome in enumerate(combo):\n",
+    "            label, prob = match_list[i][outcome]\n",
+    "            cum_prob *= prob\n",
+    "            if outcome == 'home_draw':\n",
+    "                cum_odds *= match_list[i]['home_draw_odds']\n",
+    "            elif outcome == 'away_draw':\n",
+    "                cum_odds *= match_list[i]['away_draw_odds']\n",
+    "            else:\n",
+    "                cum_odds *= match_list[i]['home_away_odds']\n",
+    "            selections.append(label)\n",
+    "        exp_value = cum_prob * (cum_odds - 1)\n",
+    "        results.append((*selections, cum_prob, cum_odds, exp_value))\n",
+    "    columns = [f'Match {i+1} Selection' for i in range(len(match_list))]\n",
+    "    columns += ['Cumulative Probability','Cumulative Odds','Expected Value']\n",
+    "    return pd.DataFrame(results, columns=columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6ea5afc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "double_df = generate_double_chance_df(matches)\n",
+    "double_df.sort_values('Expected Value', ascending=False, inplace=True)\n",
+    "double_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4eab642c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def highlight_best_bets(df, top=50):\n",
+    "    ev_thresh = df['Expected Value'].quantile(0.60)\n",
+    "    prob_min = df['Cumulative Probability'].quantile(0.40)\n",
+    "    prob_max = df['Cumulative Probability'].quantile(0.99)\n",
+    "    odds_min = df['Cumulative Odds'].quantile(0.05)\n",
+    "    filtered = df[(df['Expected Value']>=ev_thresh) &\n",
+    "                  (df['Cumulative Probability']>=prob_min) &\n",
+    "                  (df['Cumulative Probability']<=prob_max) &\n",
+    "                  (df['Cumulative Odds']>=odds_min)]\n",
+    "    return filtered.sort_values('Expected Value', ascending=False).head(top)\n",
+    "\n",
+    "best_double_bets = highlight_best_bets(double_df)\n",
+    "best_double_bets.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dad20a59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = double_df['Cumulative Probability'].values\n",
+    "y = double_df['Expected Value'].values\n",
+    "model = GradientBoostingRegressor(n_estimators=100, learning_rate=0.1, max_depth=3, random_state=42)\n",
+    "model.fit(x.reshape(-1,1), y)\n",
+    "cv = cross_val_score(model, x.reshape(-1,1), y, cv=5, scoring='neg_mean_squared_error')\n",
+    "print(f'Cross-validated MSE: {-cv.mean():.4f}')\n",
+    "\n",
+    "x_new = np.linspace(x.min(), x.max(), 200)\n",
+    "y_gb = model.predict(x_new.reshape(-1,1))\n",
+    "\n",
+    "plt.figure(figsize=(8,6))\n",
+    "plt.scatter(x, y, c=double_df['Cumulative Odds'], cmap='viridis', s=20, alpha=0.6)\n",
+    "plt.plot(x_new, y_gb, color='magenta', label='Gradient Boosting')\n",
+    "plt.colorbar(label='Cumulative Odds')\n",
+    "plt.xlabel('Cumulative Probability')\n",
+    "plt.ylabel('Expected Value')\n",
+    "plt.title('Expected Value vs Probability (Double Chance)')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6647b07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Full outcome strategy\n",
+    "outcomes = ['home', 'draw', 'away']\n",
+    "full_results = []\n",
+    "for combo in itertools.product(outcomes, repeat=len(matches)):\n",
+    "    total_prob = 1.0\n",
+    "    total_odds = 1.0\n",
+    "    labels = []\n",
+    "    for i, outcome in enumerate(combo):\n",
+    "        m = matches[i]\n",
+    "        if outcome == 'home':\n",
+    "            total_prob *= m['home_win_prob']\n",
+    "            total_odds *= m['home_win_odds']\n",
+    "            labels.append(f\"{m['match']} (home)\")\n",
+    "        elif outcome == 'draw':\n",
+    "            total_prob *= m['draw_prob']\n",
+    "            total_odds *= m['draw_odds']\n",
+    "            labels.append(f\"{m['match']} (draw)\")\n",
+    "        else:\n",
+    "            total_prob *= m['away_win_prob']\n",
+    "            total_odds *= m['away_win_odds']\n",
+    "            labels.append(f\"{m['match']} (away)\")\n",
+    "    expected_value = (total_prob * total_odds) - (1 - total_prob)\n",
+    "    full_results.append((*labels, total_prob, total_odds, expected_value))\n",
+    "columns = [f'Match {i+1}' for i in range(len(matches))] + ['Total Probability', 'Total Odds', 'Expected Value']\n",
+    "full_df = pd.DataFrame(full_results, columns=columns)\n",
+    "full_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e096e207",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected_value_threshold = full_df['Expected Value'].quantile(0.85)\n",
+    "probability_threshold_min = full_df['Total Probability'].quantile(0.45)\n",
+    "probability_threshold_max = full_df['Total Probability'].quantile(0.90)\n",
+    "odds_threshold_min = full_df['Total Odds'].quantile(0.25)\n",
+    "filtered_full = full_df[(full_df['Expected Value'] >= expected_value_threshold) &\n",
+    "                        (full_df['Total Probability'] >= probability_threshold_min) &\n",
+    "                        (full_df['Total Probability'] <= probability_threshold_max) &\n",
+    "                        (full_df['Total Odds'] >= odds_threshold_min)]\n",
+    "best_full_bets = filtered_full.sort_values(by='Expected Value', ascending=False).head(10)\n",
+    "best_full_bets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd2c5fab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,6))\n",
+    "plt.scatter(full_df['Total Probability'], full_df['Expected Value'], c=full_df['Total Odds'], cmap='viridis', s=50, alpha=0.6)\n",
+    "plt.colorbar(label='Total Odds')\n",
+    "plt.xlabel('Total Probability')\n",
+    "plt.ylabel('Expected Value')\n",
+    "plt.title('Expected Value vs Probability (Full Outcomes)')\n",
+    "plt.scatter(best_full_bets['Total Probability'], best_full_bets['Expected Value'], color='red', s=80, label='Best Bets')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Create `Consolidated_Strategies.ipynb` merging double-chance and full outcome approaches with quantile-based filtering
- Add gradient boosting visualization of expected value vs probability for combined strategies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac45394f18832bbfffccd030bd1de0